### PR TITLE
Added saving swipeController between recreating widget

### DIFF
--- a/lib/src/swiping_gesture_detector.dart
+++ b/lib/src/swiping_gesture_detector.dart
@@ -57,6 +57,12 @@ class _SwipingGestureDetector extends State<SwipingGestureDetector>
   }
 
   @override
+  void didUpdateWidget(covariant SwipingGestureDetector oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    widget.swipeController = oldWidget.swipeController;
+  }
+
+  @override
   void dispose() {
     springController.dispose();
     super.dispose();


### PR DESCRIPTION
There is a problem when SwipingGestureDetector widget recreating and in this time `late final AnimationController swipeController;` is lost because `void initState()` is called only one time.