### PR TITLE
Enable control over swiping animation speed

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,6 +25,8 @@ class ExamplePage extends StatelessWidget {
       cardWidth: 200,
       swipeThreshold: MediaQuery.of(context).size.width / 3,
       minimumVelocity: 1000,
+      rotationFactor: 0.8 / 3.14,
+      swipeAnimationDuration: const Duration(milliseconds: 500),
     );
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -39,18 +41,14 @@ class ExamplePage extends StatelessWidget {
               icon: const Icon(Icons.clear),
               iconSize: 30,
               color: Colors.red,
-              onPressed: deck.animationActive
-                  ? null
-                  : () => deck.swipeLeft(),
+              onPressed: deck.animationActive ? null : () => deck.swipeLeft(),
             ),
             const SizedBox(width: 40),
             IconButton(
               icon: const Icon(Icons.check),
               iconSize: 30,
               color: Colors.green,
-              onPressed: deck.animationActive
-                  ? null
-                  : () => deck.swipeRight(),
+              onPressed: deck.animationActive ? null : () => deck.swipeRight(),
             ),
           ],
         ),
@@ -63,9 +61,9 @@ class ExamplePage extends StatelessWidget {
     for (int i = 0; i < 500; ++i) {
       cardDeck.add(
         Card(
-          color: Color((math.Random().nextDouble() * 0xFFFFFF).toInt())
-              .withOpacity(1.0),
-          child: const SizedBox(height: 300, width: 200)),
+            color: Color((math.Random().nextDouble() * 0xFFFFFF).toInt())
+                .withOpacity(1.0),
+            child: const SizedBox(height: 300, width: 200)),
       );
     }
     return cardDeck;

--- a/lib/src/swiping_gesture_detector.dart
+++ b/lib/src/swiping_gesture_detector.dart
@@ -12,6 +12,7 @@ class SwipingGestureDetector extends StatefulWidget {
     required this.cardWidth,
     this.minimumVelocity = 1000,
     this.rotationFactor = .8 / 3.14,
+    this.swipeAnimationDuration = const Duration(milliseconds: 500),
     required this.swipeThreshold,
   }) : super(key: key);
 
@@ -21,6 +22,7 @@ class SwipingGestureDetector extends StatefulWidget {
   final double rotationFactor;
   final double swipeThreshold;
   final double cardWidth;
+  final Duration swipeAnimationDuration;
 
   Alignment dragAlignment = Alignment.center;
 
@@ -48,7 +50,7 @@ class _SwipingGestureDetector extends State<SwipingGestureDetector>
     });
 
     widget.swipeController = AnimationController(
-        vsync: this, duration: const Duration(milliseconds: 500));
+        vsync: this, duration: widget.swipeAnimationDuration);
     widget.swipeController.addListener(() {
       setState(() {
         widget.dragAlignment = widget.swipe.value;

--- a/lib/swiping_card_deck.dart
+++ b/lib/swiping_card_deck.dart
@@ -9,17 +9,18 @@ import './src/swiping_gesture_detector.dart';
 /// using a gesture or a button.
 //ignore: must_be_immutable
 class SwipingCardDeck extends StatelessWidget {
-  SwipingCardDeck({
-    Key? key,
-    required this.cardDeck,
-    required this.onLeftSwipe,
-    required this.onRightSwipe,
-    required this.onDeckEmpty,
-    required this.cardWidth,
-    this.minimumVelocity = 1000,
-    this.rotationFactor = .8 / 3.14,
-    this.swipeThreshold,
-  }) : super(key: key) {
+  SwipingCardDeck(
+      {Key? key,
+      required this.cardDeck,
+      required this.onLeftSwipe,
+      required this.onRightSwipe,
+      required this.onDeckEmpty,
+      required this.cardWidth,
+      this.minimumVelocity = 1000,
+      this.rotationFactor = .8 / 3.14,
+      this.swipeThreshold,
+      this.swipeAnimationDuration = const Duration(milliseconds: 500)})
+      : super(key: key) {
     cardDeck = cardDeck.reversed.toList();
   }
 
@@ -43,6 +44,9 @@ class SwipingCardDeck extends StatelessWidget {
 
   /// The width of all [Card] widgets in the [cardDeck].
   final double cardWidth;
+
+  /// The [Duration] of the swiping [AnimationController]
+  final Duration swipeAnimationDuration;
 
   /// The distance in pixels that a [Card] must be dragged before it is swiped.
   late final double? swipeThreshold;
@@ -68,6 +72,7 @@ class SwipingCardDeck extends StatelessWidget {
       cardWidth: cardWidth,
       rotationFactor: rotationFactor,
       minimumVelocity: minimumVelocity,
+      swipeAnimationDuration: swipeAnimationDuration,
     );
     return SizedBox(
       child: Column(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"


### PR DESCRIPTION
Expose the `duration` parameter of the `AnimationController` for the swiping animation by adding a new `swipeAnimationDuration` property to both the `SwipingCardDeck` and `SwipingGestureDetector` widgets. The property parameter is optional, with a reasonable default of 500 milliseconds. Updated the example usage to include this new optional parameter. Now the duration of the swiping animation can be set faster or slower as desired.

Resolves #21