### PR TITLE
Implement generic SwipingDeck widget

### DIFF
--- a/lib/src/swiping_gesture_detector.dart
+++ b/lib/src/swiping_gesture_detector.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 
 //ignore: must_be_immutable
-class SwipingGestureDetector extends StatefulWidget {
+class SwipingGestureDetector<T> extends StatefulWidget {
   SwipingGestureDetector({
     Key? key,
     required this.cardDeck,
@@ -16,7 +16,7 @@ class SwipingGestureDetector extends StatefulWidget {
     required this.swipeThreshold,
   }) : super(key: key);
 
-  final List<Card> cardDeck;
+  final List<T> cardDeck;
   final Function() swipeLeft, swipeRight;
   final double minimumVelocity;
   final double rotationFactor;

--- a/lib/swiping_card_deck.dart
+++ b/lib/swiping_card_deck.dart
@@ -1,15 +1,19 @@
 /// The swiping_card_deck library contains the [SwipingCardDeck] widget
-/// which allows a user to swipe through a deck of [Card] widgets.
+/// which allows a user to swipe through a deck of [Card] widgets. To
+/// swipe through any [Widget], use the generic [SwipingDeck] class.
 library swiping_card_deck;
 
 import 'package:flutter/material.dart';
 import './src/swiping_gesture_detector.dart';
 
-/// A deck of [Card] widgets that can be swiped to the left or right
+/// A [SwipingDeck] of [Card] widgets
+typedef SwipingCardDeck = SwipingDeck<Card>;
+
+/// A deck of [Widget] objects that can be swiped to the left or right
 /// using a gesture or a button.
-//ignore: must_be_immutable
-class SwipingCardDeck extends StatelessWidget {
-  SwipingCardDeck(
+// ignore: must_be_immutable
+class SwipingDeck<T extends Widget> extends StatelessWidget {
+  SwipingDeck(
       {Key? key,
       required this.cardDeck,
       required this.onLeftSwipe,
@@ -24,31 +28,31 @@ class SwipingCardDeck extends StatelessWidget {
     cardDeck = cardDeck.reversed.toList();
   }
 
-  /// The list of [Card] widgets to be swiped.
-  List<Card> cardDeck;
+  /// The list of [Widget] objects to be swiped.
+  List<T> cardDeck;
 
-  /// Callback function ran when a [Card] is swiped left.
-  final Function(Card) onLeftSwipe;
+  /// Callback function ran when a [Widget] is swiped left.
+  final Function(T) onLeftSwipe;
 
-  /// Callback function ran when a [Card] is swiped right.
-  final Function(Card) onRightSwipe;
+  /// Callback function ran when a [Widget] is swiped right.
+  final Function(T) onRightSwipe;
 
-  /// Callback function when the last [Card] in the [cardDeck] is swiped.
+  /// Callback function when the last [Widget] in the [cardDeck] is swiped.
   final Function() onDeckEmpty;
 
   /// The minimum horizontal velocity required to trigger a swipe.
   final double minimumVelocity;
 
-  /// The amount each [Card] rotates as it is swiped.
+  /// The amount each [Widget] rotates as it is swiped.
   final double rotationFactor;
 
-  /// The width of all [Card] widgets in the [cardDeck].
+  /// The width of all [Widget] objects in the [cardDeck].
   final double cardWidth;
 
   /// The [Duration] of the swiping [AnimationController]
   final Duration swipeAnimationDuration;
 
-  /// The distance in pixels that a [Card] must be dragged before it is swiped.
+  /// The distance in pixels that a [Widget] must be dragged before it is swiped.
   late final double? swipeThreshold;
 
   /// The [SwipingGestureDetector] used to control swipe animations.
@@ -87,11 +91,11 @@ class SwipingCardDeck extends StatelessWidget {
     );
   }
 
-  /// Swipe the top [Card] to the left.
+  /// Swipe the top [Widget] to the left.
   ///
   /// If there is no animation already in progress, trigger the animation
-  /// to swipe the top [Card] to the left, call the function [onLeftSwipe],
-  /// and remove the [Card] from the deck. If the deck is empty, call the
+  /// to swipe the top [Widget] to the left, call the function [onLeftSwipe],
+  /// and remove the [Widget] from the deck. If the deck is empty, call the
   /// function [onDeckEmpty].
   Future<void> swipeLeft() async {
     if (animationActive || cardDeck.isEmpty) return;
@@ -101,11 +105,11 @@ class SwipingCardDeck extends StatelessWidget {
     if (cardDeck.isEmpty) onDeckEmpty();
   }
 
-  /// Swipe the top [Card] to the right.
+  /// Swipe the top [Widget] to the right.
   ///
   /// If there is no animation already in progress, trigger the animation
-  /// to swipe the top [Card] to the right, call the function [onRightSwipe],
-  /// and remove the [Card] from the deck. If the deck is empty, call the
+  /// to swipe the top [Widget] to the right, call the function [onRightSwipe],
+  /// and remove the [Widget] from the deck. If the deck is empty, call the
   /// function [onDeckEmpty].
   Future<void> swipeRight() async {
     if (animationActive || cardDeck.isEmpty) return;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,5 +157,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.15.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.1.0
 repository: https://github.com/jushutch/swiping_card_deck
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0"
   flutter: ">=1.17.0"
 
 dependencies:

--- a/test/swiping_card_deck_test.dart
+++ b/test/swiping_card_deck_test.dart
@@ -24,8 +24,8 @@ void main() {
     SwipingCardDeck mockDeck = SwipingCardDeck(
       cardDeck: cardDeck,
       onDeckEmpty: () => debugPrint("Card deck empty"),
-      onLeftSwipe: (Card card) => debugPrint("Swiped left!"),
-      onRightSwipe: (Card card) => debugPrint("Swiped right!"),
+      onLeftSwipe: (dynamic card) => debugPrint("Swiped left!"),
+      onRightSwipe: (dynamic card) => debugPrint("Swiped right!"),
       cardWidth: 200,
     );
     await tester.pumpWidget(MaterialApp(home: Scaffold(body: mockDeck,),));

--- a/test/swiping_gesture_detector_test.dart
+++ b/test/swiping_gesture_detector_test.dart
@@ -17,7 +17,6 @@ void main() {
     }
     return cardDeck;
   }
-
   Future<void> _mountWidget(WidgetTester tester) async {
     final List<Card> cardDeck = getMockCards();
     SwipingGestureDetector mockDetector = SwipingGestureDetector(


### PR DESCRIPTION
Due to a demand for swiping through any widget, not just `Card` widgets, implemented a generic deck that can be swiped through and defined the `SwipingCardDeck` type as a `SwipingDeck` of `Card` objects. This prevents any breaking changes.

Resolves #18 