### PR TITLE
Add parameters to onSwipe callbacks

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,8 +20,10 @@ class ExamplePage extends StatelessWidget {
     final SwipingCardDeck deck = SwipingCardDeck(
       cardDeck: getCardDeck(),
       onDeckEmpty: () => debugPrint("Card deck empty"),
-      onLeftSwipe: (Card card) => debugPrint("Swiped left!"),
-      onRightSwipe: (Card card) => debugPrint("Swiped right!"),
+      onLeftSwipe: (Card card, List<Card> cardDeck, int cardsSwiped) =>
+          debugPrint("Swiped left!"),
+      onRightSwipe: (Card card, List<Card> cardDeck, int cardsSwiped) =>
+          debugPrint("Swiped right!"),
       cardWidth: 200,
       swipeThreshold: MediaQuery.of(context).size.width / 3,
       minimumVelocity: 1000,

--- a/lib/swiping_card_deck.dart
+++ b/lib/swiping_card_deck.dart
@@ -101,8 +101,7 @@ class SwipingDeck<T extends Widget> extends StatelessWidget {
   Future<void> swipeLeft() async {
     if (animationActive || cardDeck.isEmpty) return;
     await _swipeCard(left, screenSize);
-    onLeftSwipe(cardDeck.last, cardDeck, cardsSwiped);
-    ++cardsSwiped;
+    onLeftSwipe(cardDeck.last, cardDeck, ++cardsSwiped);
     cardDeck.removeLast();
     if (cardDeck.isEmpty) onDeckEmpty();
   }
@@ -116,8 +115,7 @@ class SwipingDeck<T extends Widget> extends StatelessWidget {
   Future<void> swipeRight() async {
     if (animationActive || cardDeck.isEmpty) return;
     await _swipeCard(right, screenSize);
-    onRightSwipe(cardDeck.last, cardDeck, cardsSwiped);
-    ++cardsSwiped;
+    onRightSwipe(cardDeck.last, cardDeck, ++cardsSwiped);
     cardDeck.removeLast();
     if (cardDeck.isEmpty) onDeckEmpty();
   }
@@ -138,6 +136,5 @@ class SwipingDeck<T extends Widget> extends StatelessWidget {
     await swipeDetector.swipeController.forward();
     swipeDetector.swipeController.reset();
     animationActive = false;
-    ++cardsSwiped;
   }
 }

--- a/lib/swiping_card_deck.dart
+++ b/lib/swiping_card_deck.dart
@@ -32,10 +32,10 @@ class SwipingDeck<T extends Widget> extends StatelessWidget {
   List<T> cardDeck;
 
   /// Callback function ran when a [Widget] is swiped left.
-  final Function(T) onLeftSwipe;
+  final Function(T, List<T>, int) onLeftSwipe;
 
   /// Callback function ran when a [Widget] is swiped right.
-  final Function(T) onRightSwipe;
+  final Function(T, List<T>, int) onRightSwipe;
 
   /// Callback function when the last [Widget] in the [cardDeck] is swiped.
   final Function() onDeckEmpty;
@@ -62,6 +62,7 @@ class SwipingDeck<T extends Widget> extends StatelessWidget {
   late final Size screenSize;
 
   bool animationActive = false;
+  int cardsSwiped = 0;
   static const String left = "left";
   static const String right = "right";
 
@@ -100,7 +101,8 @@ class SwipingDeck<T extends Widget> extends StatelessWidget {
   Future<void> swipeLeft() async {
     if (animationActive || cardDeck.isEmpty) return;
     await _swipeCard(left, screenSize);
-    onLeftSwipe(cardDeck.last);
+    onLeftSwipe(cardDeck.last, cardDeck, cardsSwiped);
+    ++cardsSwiped;
     cardDeck.removeLast();
     if (cardDeck.isEmpty) onDeckEmpty();
   }
@@ -114,7 +116,8 @@ class SwipingDeck<T extends Widget> extends StatelessWidget {
   Future<void> swipeRight() async {
     if (animationActive || cardDeck.isEmpty) return;
     await _swipeCard(right, screenSize);
-    onRightSwipe(cardDeck.last);
+    onRightSwipe(cardDeck.last, cardDeck, cardsSwiped);
+    ++cardsSwiped;
     cardDeck.removeLast();
     if (cardDeck.isEmpty) onDeckEmpty();
   }
@@ -135,5 +138,6 @@ class SwipingDeck<T extends Widget> extends StatelessWidget {
     await swipeDetector.swipeController.forward();
     swipeDetector.swipeController.reset();
     animationActive = false;
+    ++cardsSwiped;
   }
 }

--- a/test/swiping_card_deck_test.dart
+++ b/test/swiping_card_deck_test.dart
@@ -10,9 +10,9 @@ void main() {
     for (int i = 0; i < numCards; ++i) {
       cardDeck.add(
         Card(
-          color: Color((math.Random().nextDouble() * 0xFFFFFF).toInt())
-              .withOpacity(1.0),
-          child: const SizedBox(height: 300, width: 200)),
+            color: Color((math.Random().nextDouble() * 0xFFFFFF).toInt())
+                .withOpacity(1.0),
+            child: const SizedBox(height: 300, width: 200)),
       );
     }
     return cardDeck;
@@ -24,11 +24,17 @@ void main() {
     SwipingCardDeck mockDeck = SwipingCardDeck(
       cardDeck: cardDeck,
       onDeckEmpty: () => debugPrint("Card deck empty"),
-      onLeftSwipe: (dynamic card) => debugPrint("Swiped left!"),
-      onRightSwipe: (dynamic card) => debugPrint("Swiped right!"),
+      onLeftSwipe: (Card card, List<Card> cardDeck, int cardsSwiped) =>
+          debugPrint("Swiped left!"),
+      onRightSwipe: (Card card, List<Card> cardDeck, int cardsSwiped) =>
+          debugPrint("Swiped right!"),
       cardWidth: 200,
     );
-    await tester.pumpWidget(MaterialApp(home: Scaffold(body: mockDeck,),));
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: mockDeck,
+      ),
+    ));
   }
 
   testWidgets("SwipingCardDeck widget is created", (WidgetTester tester) async {
@@ -43,13 +49,14 @@ void main() {
     expect(cardFinder, findsNWidgets(2));
   });
 
-  testWidgets("swipeLeft removes top card and runs callback", (WidgetTester tester) async {
+  testWidgets("swipeLeft removes top card and runs callback",
+      (WidgetTester tester) async {
     await _mountWidget(tester);
     Finder cardFinder = find.byType(Card);
     expect(cardFinder, findsNWidgets(2));
     expect(tester.widget(cardFinder.first) as Card, cardDeck[1]);
     expect(tester.widget(cardFinder.last) as Card, cardDeck[0]);
-    
+
     Finder deckFinder = find.byType(SwipingCardDeck);
     expect(deckFinder, findsOneWidget);
 
@@ -61,7 +68,8 @@ void main() {
     expect(tester.widget(cardFinder.last) as Card, cardDeck[1]);
   });
 
-  testWidgets("swipeRight removes top card and runs callback", (WidgetTester tester) async {
+  testWidgets("swipeRight removes top card and runs callback",
+      (WidgetTester tester) async {
     await _mountWidget(tester);
     Finder deckFinder = find.byType(SwipingCardDeck);
     expect(deckFinder, findsOneWidget);
@@ -78,7 +86,8 @@ void main() {
     expect(tester.widget(cardFinder.last) as Card, cardDeck[1]);
   });
 
-  testWidgets("Callback function is ran when deck is empty", (WidgetTester tester) async {
+  testWidgets("Callback function is ran when deck is empty",
+      (WidgetTester tester) async {
     await _mountWidget(tester);
     Finder deckFinder = find.byType(SwipingCardDeck);
     expect(deckFinder, findsOneWidget);
@@ -93,7 +102,8 @@ void main() {
     expect(cardFinder, findsOneWidget);
     expect(tester.widget(cardFinder.first) as Card, cardDeck[numCards - 1]);
 
-    expectLater(() => deck.swipeLeft(), prints("Swiped left!\nCard deck empty\n"));
+    expectLater(
+        () => deck.swipeLeft(), prints("Swiped left!\nCard deck empty\n"));
     await tester.pumpAndSettle();
 
     expect(cardFinder, findsNothing);

--- a/test/swiping_card_deck_test.dart
+++ b/test/swiping_card_deck_test.dart
@@ -24,10 +24,14 @@ void main() {
     SwipingCardDeck mockDeck = SwipingCardDeck(
       cardDeck: cardDeck,
       onDeckEmpty: () => debugPrint("Card deck empty"),
-      onLeftSwipe: (Card card, List<Card> cardDeck, int cardsSwiped) =>
-          debugPrint("Swiped left!"),
-      onRightSwipe: (Card card, List<Card> cardDeck, int cardsSwiped) =>
-          debugPrint("Swiped right!"),
+      onLeftSwipe: (Card card, List<Card> cardDeck, int cardsSwiped) {
+        debugPrint("Swiped left!");
+        debugPrint(cardsSwiped.toString());
+      },
+      onRightSwipe: (Card card, List<Card> cardDeck, int cardsSwiped) {
+        debugPrint("Swiped right!");
+        debugPrint(cardsSwiped.toString());
+      },
       cardWidth: 200,
     );
     await tester.pumpWidget(MaterialApp(
@@ -61,7 +65,7 @@ void main() {
     expect(deckFinder, findsOneWidget);
 
     SwipingCardDeck deck = tester.widget(deckFinder);
-    expectLater(() => deck.swipeLeft(), prints("Swiped left!\n"));
+    expectLater(() => deck.swipeLeft(), prints("Swiped left!\n1\n"));
     await tester.pumpAndSettle();
     expect(cardFinder, findsNWidgets(2));
     expect(tester.widget(cardFinder.first) as Card, cardDeck[2]);
@@ -79,7 +83,7 @@ void main() {
     expect(tester.widget(cardFinder.first) as Card, cardDeck[1]);
     expect(tester.widget(cardFinder.last) as Card, cardDeck[0]);
 
-    expectLater(() => deck.swipeRight(), prints("Swiped right!\n"));
+    expectLater(() => deck.swipeRight(), prints("Swiped right!\n1\n"));
     await tester.pumpAndSettle();
     expect(cardFinder, findsNWidgets(2));
     expect(tester.widget(cardFinder.first) as Card, cardDeck[2]);
@@ -94,7 +98,7 @@ void main() {
     SwipingCardDeck deck = tester.widget(deckFinder);
 
     for (int i = 0; i < numCards - 1; ++i) {
-      deck.swipeLeft();
+      expectLater(() => deck.swipeLeft(), prints("Swiped left!\n${i + 1}\n"));
       await tester.pumpAndSettle();
     }
 
@@ -102,10 +106,83 @@ void main() {
     expect(cardFinder, findsOneWidget);
     expect(tester.widget(cardFinder.first) as Card, cardDeck[numCards - 1]);
 
-    expectLater(
-        () => deck.swipeLeft(), prints("Swiped left!\nCard deck empty\n"));
+    expectLater(() => deck.swipeLeft(),
+        prints("Swiped left!\n$numCards\nCard deck empty\n"));
     await tester.pumpAndSettle();
 
     expect(cardFinder, findsNothing);
+  });
+
+  testWidgets("CardsSwiped is incremented correctly",
+      (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder deckFinder = find.byType(SwipingCardDeck);
+    expect(deckFinder, findsOneWidget);
+    SwipingCardDeck deck = tester.widget(deckFinder);
+
+    for (int i = 0; i < numCards - 1; ++i) {
+      expectLater(() => deck.swipeLeft(), prints("Swiped left!\n${i + 1}\n"));
+      await tester.pumpAndSettle();
+    }
+
+    Finder cardFinder = find.byType(Card);
+    expect(cardFinder, findsOneWidget);
+    expect(tester.widget(cardFinder.first) as Card, cardDeck[numCards - 1]);
+  });
+
+  testWidgets("CardDeck can be modified with both swipe callbacks",
+      (WidgetTester tester) async {
+    // Add a card to the beginning of a deck
+    void addCard(List<Card> deck) {
+      deck.insert(
+        0,
+        const Card(
+            color: Colors.black, child: SizedBox(height: 300, width: 200)),
+      );
+    }
+
+    // SwipingCardDeck with swipe callbacks that modify the cardDeck
+    SwipingCardDeck mockDeck = SwipingCardDeck(
+      cardDeck: const [
+        Card(color: Colors.black, child: SizedBox(height: 300, width: 200))
+      ],
+      onDeckEmpty: () => debugPrint("Card deck empty"),
+      onLeftSwipe: (Card card, List<Card> cardDeck, int cardsSwiped) {
+        addCard(cardDeck);
+        debugPrint("Cards Swiped: $cardsSwiped");
+      },
+      onRightSwipe: (Card card, List<Card> cardDeck, int cardsSwiped) {
+        addCard(cardDeck);
+        debugPrint("Cards Swiped: $cardsSwiped");
+      },
+      cardWidth: 200,
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: mockDeck,
+      ),
+    ));
+
+    Finder deckFinder = find.byType(SwipingCardDeck);
+    expect(deckFinder, findsOneWidget);
+    SwipingCardDeck deck = tester.widget(deckFinder);
+    int cardsSwiped = 0;
+
+    // Alternate swiping directions
+    for (int i = 0; i < 100; ++i) {
+      ++cardsSwiped;
+      if (i % 2 == 0) {
+        expectLater(
+            () => deck.swipeLeft(), prints("Cards Swiped: $cardsSwiped\n"));
+      } else {
+        expectLater(
+            () => deck.swipeRight(), prints("Cards Swiped: $cardsSwiped\n"));
+      }
+
+      await tester.pumpAndSettle();
+      Finder cardFinder = find.byType(Card);
+      expect(cardFinder, findsOneWidget);
+    }
   });
 }


### PR DESCRIPTION
Added two parameters to the `onLeftSwipe` and `onRightSwipe` callback functions: `cardDeck` and `cardsSwiped`. The purpose of the first parameter is to allow users of the package to modify the deck during the callback. One potential use case is described in issue #23, where a user wants to add new cards to the end of the deck dynamically. The second parameter allows users to access the number of cards swiped so far in this deck. This can be useful for determining the current index in the deck, as requested in issue #20. Here is a basic example of using both parameters:
```Dart
onLeftSwipe: (Card card, List<Card> cardDeck, int cardsSwiped) {
  // insert a new card into the back of the deck
  cardDeck.insert(0, const Card(
              color: Colors.black, child: SizedBox(height: 300, width: 200)),
  );

  // print the number of cards that have been swiped
  debugPrint("Number of cards swiped: $cardsSwiped");
}
```

Since this is a breaking change, it will first be part of pre-release v2.0.0-dev.0.

Resolves #20 
Resolves #23 