### PR TITLE
Add option to disable swiping by dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ SwipingCardDeck(
     cardWidth: 200,
     rotationFactor: 0.8 / 3.14,
     swipeAnimationDuration: const Duration(milliseconds: 500),
+    disableDragging: false,
 );
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,6 +27,7 @@ class ExamplePage extends StatelessWidget {
       minimumVelocity: 1000,
       rotationFactor: 0.8 / 3.14,
       swipeAnimationDuration: const Duration(milliseconds: 500),
+      disableDragging: false,
     );
     return Column(
       mainAxisSize: MainAxisSize.min,

--- a/lib/swiping_card_deck.dart
+++ b/lib/swiping_card_deck.dart
@@ -23,7 +23,8 @@ class SwipingDeck<T extends Widget> extends StatelessWidget {
       this.minimumVelocity = 1000,
       this.rotationFactor = .8 / 3.14,
       this.swipeThreshold,
-      this.swipeAnimationDuration = const Duration(milliseconds: 500)})
+      this.swipeAnimationDuration = const Duration(milliseconds: 500),
+      this.disableDragging = false})
       : super(key: key) {
     cardDeck = cardDeck.reversed.toList();
   }
@@ -49,8 +50,11 @@ class SwipingDeck<T extends Widget> extends StatelessWidget {
   /// The width of all [Widget] objects in the [cardDeck].
   final double cardWidth;
 
-  /// The [Duration] of the swiping [AnimationController]
+  /// The [Duration] of the swiping [AnimationController].
   final Duration swipeAnimationDuration;
+
+  /// Disable swiping cards using the dragging gesture.
+  final bool disableDragging;
 
   /// The distance in pixels that a [Widget] must be dragged before it is swiped.
   late final double? swipeThreshold;
@@ -77,6 +81,7 @@ class SwipingDeck<T extends Widget> extends StatelessWidget {
       rotationFactor: rotationFactor,
       minimumVelocity: minimumVelocity,
       swipeAnimationDuration: swipeAnimationDuration,
+      disableDragging: disableDragging,
     );
     return SizedBox(
       child: Column(

--- a/test/swiping_card_deck_test.dart
+++ b/test/swiping_card_deck_test.dart
@@ -10,9 +10,9 @@ void main() {
     for (int i = 0; i < numCards; ++i) {
       cardDeck.add(
         Card(
-          color: Color((math.Random().nextDouble() * 0xFFFFFF).toInt())
-              .withOpacity(1.0),
-          child: const SizedBox(height: 300, width: 200)),
+            color: Color((math.Random().nextDouble() * 0xFFFFFF).toInt())
+                .withOpacity(1.0),
+            child: const SizedBox(height: 300, width: 200)),
       );
     }
     return cardDeck;
@@ -28,7 +28,11 @@ void main() {
       onRightSwipe: (dynamic card) => debugPrint("Swiped right!"),
       cardWidth: 200,
     );
-    await tester.pumpWidget(MaterialApp(home: Scaffold(body: mockDeck,),));
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: mockDeck,
+      ),
+    ));
   }
 
   testWidgets("SwipingCardDeck widget is created", (WidgetTester tester) async {
@@ -43,13 +47,14 @@ void main() {
     expect(cardFinder, findsNWidgets(2));
   });
 
-  testWidgets("swipeLeft removes top card and runs callback", (WidgetTester tester) async {
+  testWidgets("swipeLeft removes top card and runs callback",
+      (WidgetTester tester) async {
     await _mountWidget(tester);
     Finder cardFinder = find.byType(Card);
     expect(cardFinder, findsNWidgets(2));
     expect(tester.widget(cardFinder.first) as Card, cardDeck[1]);
     expect(tester.widget(cardFinder.last) as Card, cardDeck[0]);
-    
+
     Finder deckFinder = find.byType(SwipingCardDeck);
     expect(deckFinder, findsOneWidget);
 
@@ -61,7 +66,8 @@ void main() {
     expect(tester.widget(cardFinder.last) as Card, cardDeck[1]);
   });
 
-  testWidgets("swipeRight removes top card and runs callback", (WidgetTester tester) async {
+  testWidgets("swipeRight removes top card and runs callback",
+      (WidgetTester tester) async {
     await _mountWidget(tester);
     Finder deckFinder = find.byType(SwipingCardDeck);
     expect(deckFinder, findsOneWidget);
@@ -78,7 +84,8 @@ void main() {
     expect(tester.widget(cardFinder.last) as Card, cardDeck[1]);
   });
 
-  testWidgets("Callback function is ran when deck is empty", (WidgetTester tester) async {
+  testWidgets("Callback function is ran when deck is empty",
+      (WidgetTester tester) async {
     await _mountWidget(tester);
     Finder deckFinder = find.byType(SwipingCardDeck);
     expect(deckFinder, findsOneWidget);
@@ -93,7 +100,8 @@ void main() {
     expect(cardFinder, findsOneWidget);
     expect(tester.widget(cardFinder.first) as Card, cardDeck[numCards - 1]);
 
-    expectLater(() => deck.swipeLeft(), prints("Swiped left!\nCard deck empty\n"));
+    expectLater(
+        () => deck.swipeLeft(), prints("Swiped left!\nCard deck empty\n"));
     await tester.pumpAndSettle();
 
     expect(cardFinder, findsNothing);

--- a/test/swiping_gesture_detector_test.dart
+++ b/test/swiping_gesture_detector_test.dart
@@ -12,11 +12,13 @@ void main() {
         Card(
           color: Color((math.Random().nextDouble() * 0xFFFFFF).toInt())
               .withOpacity(1.0),
-          child: const SizedBox(height: 300, width: 200)),
+          child: const SizedBox(height: 300, width: 200),
+        ),
       );
     }
     return cardDeck;
   }
+
   Future<void> _mountWidget(WidgetTester tester) async {
     final List<Card> cardDeck = getMockCards();
     SwipingGestureDetector mockDetector = SwipingGestureDetector(
@@ -24,53 +26,80 @@ void main() {
       swipeLeft: () {
         debugPrint("Swiped left!");
         cardDeck.removeLast();
-      }, 
+      },
       swipeRight: () {
         debugPrint("Swiped right!");
         cardDeck.removeLast();
-      }, 
+      },
       cardWidth: 200,
       swipeThreshold: 200,
       minimumVelocity: 1000,
       rotationFactor: 0,
     );
-    await tester.pumpWidget(MaterialApp(home: Scaffold(body: mockDetector,),));
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: mockDetector,
+      ),
+    ));
   }
 
-  testWidgets("SwipingCardDeck widget is created", (WidgetTester tester) async {
+  Future<void> _mountDisabledWidget(WidgetTester tester) async {
+    final List<Card> cardDeck = getMockCards();
+    SwipingGestureDetector mockDetector = SwipingGestureDetector(
+      cardDeck: cardDeck,
+      swipeLeft: () {
+        debugPrint("Swiped left!");
+        cardDeck.removeLast();
+      },
+      swipeRight: () {
+        debugPrint("Swiped right!");
+        cardDeck.removeLast();
+      },
+      cardWidth: 200,
+      swipeThreshold: 200,
+      minimumVelocity: 1000,
+      rotationFactor: 0,
+      disableDragging: true,
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: mockDetector,
+      ),
+    ));
+  }
+
+  testWidgets("SwipingGestureDetector widget is created",
+      (WidgetTester tester) async {
     await _mountWidget(tester);
     Finder gestureFinder = find.byType(SwipingGestureDetector);
     expect(gestureFinder, findsOneWidget);
   });
 
-  testWidgets("Card is swiped at correct thresholds", (WidgetTester tester) async {
+  testWidgets("Card is swiped at correct thresholds",
+      (WidgetTester tester) async {
     await _mountWidget(tester);
     Finder gestureFinder = find.byType(SwipingGestureDetector);
     expect(gestureFinder, findsOneWidget);
     SwipingGestureDetector detector = tester.widget(gestureFinder);
-    
+
     // Test the right swipe threshold
     await expectLater(
-      () async => await tester.drag(gestureFinder, const Offset(200, 0)), 
-      prints("Swiped right!\n")
-    );
+        () async => await tester.drag(gestureFinder, const Offset(200, 0)),
+        prints("Swiped right!\n"));
     expect(detector.cardDeck.length, numCards - 1);
     await expectLater(
-      () async => await tester.drag(gestureFinder, const Offset(199, 0)), 
-      prints("")
-    );
+        () async => await tester.drag(gestureFinder, const Offset(199, 0)),
+        prints(""));
     expect(detector.cardDeck.length, numCards - 1);
 
     // Test the left swipe threshold
     await expectLater(
-      () async => await tester.drag(gestureFinder, const Offset(-200, 0)), 
-      prints("Swiped left!\n")
-    );
+        () async => await tester.drag(gestureFinder, const Offset(-200, 0)),
+        prints("Swiped left!\n"));
     expect(detector.cardDeck.length, numCards - 2);
     await expectLater(
-      () async => await tester.drag(gestureFinder, const Offset(-199, 0)), 
-      prints("")
-    );
+        () async => await tester.drag(gestureFinder, const Offset(-199, 0)),
+        prints(""));
     expect(detector.cardDeck.length, numCards - 2);
   });
 
@@ -92,7 +121,8 @@ void main() {
     await tester.pumpAndSettle();
 
     Offset newCenter = tester.getCenter(topCardFinder);
-    newCenter = Offset(newCenter.dx.round().toDouble(), newCenter.dy.round().toDouble());
+    newCenter = Offset(
+        newCenter.dx.round().toDouble(), newCenter.dy.round().toDouble());
     expect(newCenter, initial + const Offset(30, 0));
 
     // Assert that the top card is animated after the drag is released
@@ -104,42 +134,80 @@ void main() {
     // Assert that the top card returns to the initial position
     await tester.pumpAndSettle();
     newCenter = tester.getCenter(topCardFinder);
-    newCenter = Offset(newCenter.dx.round().toDouble(), newCenter.dy.round().toDouble());
+    newCenter = Offset(
+        newCenter.dx.round().toDouble(), newCenter.dy.round().toDouble());
     expect(newCenter, initial);
   });
 
-  testWidgets("Card is swiped at minimum velocity", (WidgetTester tester) async {
+  testWidgets("Card is swiped at minimum velocity",
+      (WidgetTester tester) async {
     // NOTE: The fling velocity values are slightly generous due to the
     // imprecision of the drag details velocity.
     await _mountWidget(tester);
     Finder gestureFinder = find.byType(SwipingGestureDetector);
     expect(gestureFinder, findsOneWidget);
     SwipingGestureDetector detector = tester.widget(gestureFinder);
-    
+
     // Test the right swipe velocity
     await expectLater(
-      () async => await tester.fling(gestureFinder, const Offset(199, 0), 1001), 
-      prints("Swiped right!\n")
-    );
-    //await tester.flingFrom(tester.getCenter(gestureFinder), const Offset(199, 0), 1000);
+        () async =>
+            await tester.fling(gestureFinder, const Offset(199, 0), 1001),
+        prints("Swiped right!\n"));
     expect(detector.cardDeck.length, numCards - 1);
     await expectLater(
-      () async => await tester.fling(gestureFinder, const Offset(199, 0), 999), 
-      prints("")
-    );
+        () async =>
+            await tester.fling(gestureFinder, const Offset(199, 0), 999),
+        prints(""));
     expect(detector.cardDeck.length, numCards - 1);
     await tester.pumpAndSettle();
 
     // Test the left swipe velocity
     await expectLater(
-      () async => await tester.fling(gestureFinder, const Offset(-199, 0), 1001), 
-      prints("Swiped left!\n")
-    );
+        () async =>
+            await tester.fling(gestureFinder, const Offset(-199, 0), 1001),
+        prints("Swiped left!\n"));
     expect(detector.cardDeck.length, numCards - 2);
     await expectLater(
-      () async => await tester.fling(gestureFinder, const Offset(-199, 0), 999), 
-      prints("")
-    );
+        () async =>
+            await tester.fling(gestureFinder, const Offset(-199, 0), 999),
+        prints(""));
     expect(detector.cardDeck.length, numCards - 2);
+  });
+
+  testWidgets("Card cannot be swiped when dragging is disabled",
+      (WidgetTester tester) async {
+    // NOTE: The fling velocity values are slightly generous due to the
+    // imprecision of the drag details velocity.
+    await _mountDisabledWidget(tester);
+    Finder gestureFinder = find.byType(SwipingGestureDetector);
+    expect(gestureFinder, findsOneWidget);
+    SwipingGestureDetector detector = tester.widget(gestureFinder);
+
+    // Test flinging to the right
+    await expectLater(
+        () async =>
+            await tester.fling(gestureFinder, const Offset(199, 0), 1001),
+        prints(""));
+    expect(detector.cardDeck.length, numCards);
+    await tester.pumpAndSettle();
+
+    // Test flinging to the left
+    await expectLater(
+        () async =>
+            await tester.fling(gestureFinder, const Offset(-199, 0), 1001),
+        prints(""));
+    expect(detector.cardDeck.length, numCards);
+
+    // Test the right swipe threshold
+    await expectLater(
+        () async => await tester.drag(gestureFinder, const Offset(200, 0)),
+        prints(""));
+    expect(detector.cardDeck.length, numCards);
+
+    // Test the left swipe threshold
+    await expectLater(
+        () async => await tester.drag(gestureFinder, const Offset(-200, 0)),
+        prints(""));
+    expect(detector.cardDeck.length, numCards);
   });
 }


### PR DESCRIPTION
Add new boolean parameter to `SwipingCardDeck` called `disableDragging` in order to optionally prevent cards from being swiped using a dragging gesture. The default value is `false` in order to prevent breaking changes. Note that the swiping hooks still allow for cards to be swiped using buttons. Wrote tests to validate that cards cannot be swiped by dragging or flinging.

Resolves #35